### PR TITLE
Cloud destinations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-        "@evefan/evefan-config": "^0.1.15",
+        "@evefan/evefan-config": "^0.1.16",
         "@types/node": "20.8.3",
         "@types/ua-parser-js": "^0.7.39",
         "@types/uuid": "^10.0.0",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@evefan/evefan-config": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@evefan/evefan-config/-/evefan-config-0.1.15.tgz",
-      "integrity": "sha512-kmaM2lontpT2xFHuUtb2npfnsZEFrn2DHXSJg7wtBesAUXYd744+Gbu4p/F+YtLNOPJVqFXgiSvF15JUKvfoMg==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@evefan/evefan-config/-/evefan-config-0.1.16.tgz",
+      "integrity": "sha512-r4FXZlRJi8yFl6nos1h+Hq7Gv9RMkEabJOV0Z5uUSsVZIQTKA/uShpJzYMUhocsXLFVZZNwz540C15xl/8nxaw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-        "@evefan/evefan-config": "^0.1.11",
+        "@evefan/evefan-config": "^0.1.15",
         "@types/node": "20.8.3",
         "@types/ua-parser-js": "^0.7.39",
         "@types/uuid": "^10.0.0",
@@ -560,10 +560,11 @@
       }
     },
     "node_modules/@evefan/evefan-config": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@evefan/evefan-config/-/evefan-config-0.1.11.tgz",
-      "integrity": "sha512-FFnGJNky0hq83V1WtWeOHqTS4UODw8GE6FS0d8p58/2Yew9NLBtM8eIdvv7KR57xDyOc1XzcP014YeZFxDZR5A==",
-      "dev": true
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@evefan/evefan-config/-/evefan-config-0.1.15.tgz",
+      "integrity": "sha512-kmaM2lontpT2xFHuUtb2npfnsZEFrn2DHXSJg7wtBesAUXYd744+Gbu4p/F+YtLNOPJVqFXgiSvF15JUKvfoMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-    "@evefan/evefan-config": "^0.1.11",
+    "@evefan/evefan-config": "^0.1.15",
     "@types/node": "20.8.3",
     "@types/ua-parser-js": "^0.7.39",
     "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-    "@evefan/evefan-config": "^0.1.15",
+    "@evefan/evefan-config": "^0.1.16",
     "@types/node": "20.8.3",
     "@types/ua-parser-js": "^0.7.39",
     "@types/uuid": "^10.0.0",

--- a/src/connectors/bigquery/index.ts
+++ b/src/connectors/bigquery/index.ts
@@ -5,7 +5,11 @@ import { DestinationEvent, DestinationEventType } from '../../event';
 import { propertyWithPath } from '../../utils';
 import { FanOutResult } from '../../writer';
 import { Field, schema } from '../../persistance/schema';
-import { BigqueryConfig, BigqueryDestination } from '@evefan/evefan-config';
+import {
+  BigqueryConfig,
+  BigqueryDestination,
+  DestinationType,
+} from '@evefan/evefan-config';
 
 const DESTINATION_TYPE = 'bigquery';
 
@@ -289,7 +293,8 @@ async function writeEvents(
 export default class BigqueryConnector implements Connector {
   async write(
     config: WorkerConfig,
-    events: DestinationEvent[]
+    events: DestinationEvent[],
+    destinationType: DestinationType
   ): Promise<FanOutResult> {
     const destination = config.destinations.find(
       (d) => d.type === DESTINATION_TYPE

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,3 +1,4 @@
+import { DestinationType } from '@evefan/evefan-config';
 import { WorkerConfig } from '../config';
 import { DestinationEvent } from '../event';
 import { FanOutResult } from '../writer';
@@ -5,7 +6,8 @@ import { FanOutResult } from '../writer';
 export interface Connector {
   write(
     config: WorkerConfig,
-    events: DestinationEvent[]
+    events: DestinationEvent[],
+    destinationType: DestinationType
   ): Promise<FanOutResult>;
 }
 

--- a/src/connectors/mixpanel/index.ts
+++ b/src/connectors/mixpanel/index.ts
@@ -1,4 +1,8 @@
-import { MixpanelConfig, MixpanelDestination } from '@evefan/evefan-config';
+import {
+  DestinationType,
+  MixpanelConfig,
+  MixpanelDestination,
+} from '@evefan/evefan-config';
 import { Connector } from '..';
 import { WorkerConfig } from '../../config';
 import {
@@ -372,7 +376,8 @@ const transformEvents = (
 export default class MixpanelConnector implements Connector {
   async write(
     config: WorkerConfig,
-    events: DestinationEvent[]
+    events: DestinationEvent[],
+    destinationType: DestinationType
   ): Promise<FanOutResult> {
     const destination = config.destinations.find(
       (d) => d.type === DESTINATION_TYPE

--- a/src/connectors/postgres/index.ts
+++ b/src/connectors/postgres/index.ts
@@ -5,7 +5,11 @@ import { DestinationEvent, DestinationEventType } from '../../event';
 import { propertyWithPath } from '../../utils';
 import { FanOutResult } from '../../writer';
 import { Field, schema } from '../../persistance/schema';
-import { PostgresConfig, PostgresDestination } from '@evefan/evefan-config';
+import {
+  DestinationType,
+  PostgresConfig,
+  PostgresDestination,
+} from '@evefan/evefan-config';
 
 const DESTINATION_TYPE = 'postgres';
 
@@ -145,7 +149,8 @@ const writeEvents = async (
 export default class PostgresConnector implements Connector {
   async write(
     config: WorkerConfig,
-    events: DestinationEvent[]
+    events: DestinationEvent[],
+    destinationType: DestinationType
   ): Promise<FanOutResult> {
     const destination = config.destinations.find(
       (d) => d.type === DESTINATION_TYPE


### PR DESCRIPTION
This introduces support for cloud destinations handled by the Evefan Console for those with a paid plan. If a destination does not have a handler implemented and its a cloud destination based on the `@evefancom/config` package it'll route it there. 